### PR TITLE
fix: use file's basename instead of passed argument

### DIFF
--- a/src/crs_linter/cli.py
+++ b/src/crs_linter/cli.py
@@ -7,6 +7,7 @@ import msc_pyparser
 import difflib
 import argparse
 import re
+import os.path
 from dulwich.contrib.release_robot import get_current_version, get_recent_tags
 from semver import Version
 
@@ -136,7 +137,7 @@ def check_indentation(filename, content):
     try:
         with open(filename, "r") as fp:
             from_lines = fp.readlines()
-            if filename.startswith("crs-setup.conf.example"):
+            if os.path.basename(filename).startswith("crs-setup.conf.example"):
                 from_lines = remove_comments("".join(from_lines)).split("\n")
                 from_lines = [l + "\n" for l in from_lines]
     except:


### PR DESCRIPTION
The linter processes all rules if the current file is `crs-setup.conf.example`, including the commented ones. This is because we set many variables in them.

For eg: we use `TX:ENABLE_DEFAULT_COLLECTION` in rule [901320](https://github.com/coreruleset/coreruleset/blob/10eaa51f68c4ad8c80ec7bcf4b637ec24cc1c234/rules/REQUEST-901-INITIALIZATION.conf#L333), but it's not set, but there is a commented rule in [crs-setup.conf.example](https://github.com/coreruleset/coreruleset/blob/10eaa51f68c4ad8c80ec7bcf4b637ec24cc1c234/crs-setup.conf.example#L434-L442).

There was a typo in linter: it processed the commented rules only if the name started clearly `crs-setup.conf.example`, and this value was checked from the argument. This means if you pass the argument like `-r crs-setup.conf.example`, then it processes, but if you pass like `-r ./crs-setup.conf.example` then it does not. This explains why I get [#coreruleset/4058](https://github.com/coreruleset/coreruleset/issues/4058) result in local.

This PR changes this wrong behavior, now it looks the basename of the file was given.