### PR TITLE
chore: bump CRS version to 4.15.0 in GH test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: true
       matrix:
         # renovate: datasource=github-releases depName=coreruleset/coreruleset
-        crs-version: ['4.14.0']
+        crs-version: ['4.15.0']
         python-version: ['3.11', '3.12', '3.13']
 
     steps:


### PR DESCRIPTION
This PR needs to fix old issues.
See #39.
