### PR TITLE
chore: fix CRS_VERSION in test.yml

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: true
       matrix:
         # renovate: datasource=github-releases depName=coreruleset/coreruleset
-        CRS_VERSION: v4.16.0
+        CRS_VERSION: ['4.16.0']
         python-version: ['3.11', '3.12', '3.13']
 
     steps:


### PR DESCRIPTION
Renovate doesn't update the CRS_VERSION variable correctly.