### PR TITLE
feat: bump CRS to 4.17.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,5 +45,5 @@ jobs:
       - name: "Run crs linter tests for ${{ matrix.CRS_VERSION }}"
         run: |
           curl -sSL  https://github.com/coreruleset/coreruleset/archive/refs/tags/v${{ matrix.CRS_VERSION }}.tar.gz -o - | \
-            tar xzvf - --strip-components=1 --wildcards "*/rules/*" "*/tests/*" "*/crs-setup.conf.example"
-          uv run crs-linter --debug -o github -d . -r crs-setup.conf.example -r 'rules/*.conf' -t APPROVED_TAGS -f FILENAME_EXCLUSIONS -v ${{ matrix.CRS_VERSION }} -T 'tests/regression/tests/' -E TESTS_EXCLUSIONS
+            tar xzvf - --strip-components=1 --wildcards "*/rules/*" "*/tests/*" "*/crs-setup.conf.example" "*/util/*"
+          uv run crs-linter --debug -o github -d . -r crs-setup.conf.example -r 'rules/*.conf' -t util/APPROVED_TAGS -f util/FILENAME_EXCLUSIONS -v ${{ matrix.CRS_VERSION }} -T 'tests/regression/tests/' -E util/TESTS_EXCLUSIONS


### PR DESCRIPTION
This is necessary to finish #52.

Hint: if we have a release procedure for CRS, could we add this step into that?