### PR TITLE
fix: try to fix renvovates bad version updates for CRS

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        # renovate: datasource=github-releases depName=coreruleset/coreruleset
+        # renovate: datasource=github-releases depName=coreruleset/coreruleset versioning=semver
         CRS_VERSION: ['4.17.1']
         python-version: ['3.11', '3.12', '3.13']
 


### PR DESCRIPTION
Renovate for some reason replaces `['<version>']` with `<version>`, making the YAML invalid. Try to use a different versioning scheme that is stricter to fix this.