### PR TITLE
Immediately return with exit code 1 if failed to parse a rule file.

### DIFF
--- a/src/crs_linter/cli.py
+++ b/src/crs_linter/cli.py
@@ -89,7 +89,7 @@ def read_files(filenames):
                 line=err["line"],
                 end_line=err["line"],
             )
-            continue
+            sys.exit(1)
 
     return parsed, file_contents
 


### PR DESCRIPTION
If a rule file does not exist, the linter immediately returns with exit code 1.

However if the file exists but can't be parsed, the linter just ignores that file.

By also immediately returning with exit code 1 if a file can't be parsed properly, the behavior is self-consistent and one can solely rely on the exit code as status, that all files could be parsed, linted and comply with the spec.