### PR TITLE
feat: add fail fast when parsing

### DIFF
--- a/src/crs_linter/cli.py
+++ b/src/crs_linter/cli.py
@@ -46,7 +46,7 @@ def get_crs_version(directory, version=None, head_ref=None, commit_message=None)
     return crs_version
 
 
-def read_files(filenames):
+def read_files(filenames, fail_fast=False):
     """ Iterate over the files and parse them using the msc_pyparser"""
     global logger
 
@@ -89,6 +89,9 @@ def read_files(filenames):
                 line=err["line"],
                 end_line=err["line"],
             )
+            if fail_fast:
+                sys.exit(1)
+            # Skip this file and continue with the next one
             continue
 
     return parsed, file_contents
@@ -129,6 +132,12 @@ def parse_args(argv):
     )
     parser.add_argument(
         "--debug", dest="debug", help="Show debug information.", action="store_true"
+    )
+    parser.add_argument(
+        "--fail-fast",
+        dest="fail_fast",
+        help="Exit immediately on parsing errors instead of continuing.",
+        action="store_true",
     )
     parser.add_argument(
         "-r",
@@ -211,7 +220,7 @@ def main():
     filename_tags_exclusions = []
     if args.filename_tags_exclusions is not None:
         filename_tags_exclusions = get_lines_from_file(args.filename_tags_exclusions)
-    parsed, file_contents = read_files(files)
+    parsed, file_contents = read_files(files, fail_fast=args.fail_fast)
     txvars = {} # Shared dict for tracking TX variables across all files
     ids = {}  # Shared dict for tracking rule IDs across all files
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,5 @@
 import sys
+import pytest
 
 from crs_linter.cli import *
 from pathlib import Path
@@ -68,3 +69,81 @@ def test_generate_version_string_ignoring_post_branch_name():
     except NotGitRepository as ex:
         caught = True
     assert caught
+
+
+def test_parsing_failure_exits_with_error_code_when_fail_fast(monkeypatch, tmp_path):
+    """Test that parsing failures exit with code 1 when --fail-fast is used"""
+    # Create a malformed rule file that will fail parsing
+    invalid_rule = tmp_path / "invalid.conf"
+    invalid_rule.write_text("SecRule INVALID SYNTAX @@@@ THIS WILL NOT PARSE")
+
+    # Create required config files
+    approved_tags = tmp_path / "APPROVED_TAGS"
+    test_exclusions = tmp_path / "TEST_EXCLUSIONS"
+    approved_tags.write_text("")
+    test_exclusions.write_text("")
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "crs-linter",
+            "-v",
+            "4.10.0",
+            "-r",
+            str(invalid_rule),
+            "-t",
+            str(approved_tags),
+            "-E",
+            str(test_exclusions),
+            "--fail-fast",
+        ],
+    )
+
+    # The program should exit with code 1 when parsing fails with --fail-fast
+    with pytest.raises(SystemExit) as exc_info:
+        main()
+
+    assert exc_info.value.code == 1
+
+
+def test_parsing_failure_continues_without_fail_fast(monkeypatch, tmp_path):
+    """Test that parsing failures continue without --fail-fast (default behavior)"""
+    # Create a malformed rule file that will fail parsing
+    invalid_rule = tmp_path / "invalid.conf"
+    invalid_rule.write_text("SecRule INVALID SYNTAX @@@@ THIS WILL NOT PARSE")
+
+    # Create a valid rule file
+    valid_rule = tmp_path / "valid.conf"
+    valid_rule.write_text("")
+
+    # Create required config files
+    approved_tags = tmp_path / "APPROVED_TAGS"
+    test_exclusions = tmp_path / "TEST_EXCLUSIONS"
+    approved_tags.write_text("")
+    test_exclusions.write_text("")
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "crs-linter",
+            "-v",
+            "4.10.0",
+            "-r",
+            str(invalid_rule),
+            "-r",
+            str(valid_rule),
+            "-t",
+            str(approved_tags),
+            "-E",
+            str(test_exclusions),
+        ],
+    )
+
+    # The program should continue and return 0 (since there are no linting errors in the valid file)
+    # Note: The parsing error will be logged but won't cause an exit
+    ret = main()
+
+    # Should return 0 because the valid file has no linting issues
+    assert ret == 0


### PR DESCRIPTION
## what

- add `--fail-fast` flag to fail on parsed file errors

## why

- allow to exit fast instead of running all the linter phases

## references

- fixes #105 