### PR TITLE
feat: add lint rule for standalong tx:N

### DIFF
--- a/src/crs_linter/linter.py
+++ b/src/crs_linter/linter.py
@@ -18,6 +18,7 @@ from .rules import (
     ordered_actions,
     pl_consistency,
     rule_tests,
+    standalone_txn,
     variables_usage,
     version
 )

--- a/src/crs_linter/rules/standalone_txn.py
+++ b/src/crs_linter/rules/standalone_txn.py
@@ -1,0 +1,101 @@
+import re
+from crs_linter.lint_problem import LintProblem
+from crs_linter.rule import Rule
+
+
+class StandaloneTxn(Rule):
+    """Check that TX.N variables are not used as targets in standalone rules.
+
+    This rule prevents TX.N capture group variables (TX:0, TX:1, TX:2, etc.)
+    from being used as rule targets in standalone rules. Standalone rules have
+    no control over what values exist in TX.N from previous unrelated rules,
+    making such usage unpredictable and error-prone.
+
+    TX.N variables should only be used in chained rules where the parent rule
+    in the chain sets the value (typically via regex matching).
+
+    Example of a failing rule (standalone rule using TX.N):
+        SecRule "TX:4" "@eq 1" \\
+            "id:3,\\
+            phase:2,\\
+            deny"  # Fails: standalone rule using TX:4
+
+    Example of a passing rule (chained rule using TX.N):
+        SecRule ARGS "@rx (ab|cd)?(ef)" \\
+            "id:1,\\
+            phase:2,\\
+            deny,\\
+            chain"
+            SecRule "TX:1" "@eq ef"  # OK: TX:1 used in chained rule
+
+    Note: This check complements the CheckCapture rule, which ensures that
+    TX.N usage requires a capture action. This rule specifically addresses
+    the issue of TX.N in standalone rules where values are unpredictable.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.name = "standalonetxn"
+        self.success_message = "No standalone rules use TX.N as target."
+        self.error_message = "One or more standalone rules use TX.N as target."
+        self.error_title = "TX.N in standalone rule"
+        self.args = ("data",)
+
+        # Pattern to match numeric TX variables: TX:0, TX:1, etc.
+        self.txn_pattern = re.compile(r"^\d$")
+
+    def check(self, data):
+        """
+        Check that TX.N variables are not used as targets in standalone rules.
+
+        A rule is considered standalone if it's not preceded by a rule with
+        the 'chain' action. TX.N targets are only allowed in chained rules.
+        """
+        is_chained = False  # Tracks if current rule is part of a chain
+        current_rule_id = 0
+
+        for d in data:
+            # Only check SecRule directives
+            if d["type"].lower() != "secrule":
+                continue
+
+            # Check if this rule uses TX.N as a target
+            uses_txn_target = False
+            for v in d["variables"]:
+                if (v["variable"].lower() == "tx" and
+                    self.txn_pattern.match(v["variable_part"])):
+                    uses_txn_target = True
+                    break
+
+            # If this is a standalone rule using TX.N, flag it
+            if uses_txn_target and not is_chained:
+                # Get rule ID for better error message
+                rule_id = current_rule_id
+                if "actions" in d:
+                    for a in d["actions"]:
+                        if a["act_name"] == "id":
+                            rule_id = int(a["act_arg"])
+                            break
+
+                yield LintProblem(
+                    line=d.get("lineno", 0),
+                    end_line=d.get("lineno", 0),
+                    desc=f"standalone rule uses TX.N as target; rule id: {rule_id}",
+                    rule="standalonetxn",
+                )
+
+            # Update chained state for next rule
+            # Check if this rule has a 'chain' action
+            if "actions" in d:
+                has_chain_action = False
+                for a in d["actions"]:
+                    if a["act_name"] == "id":
+                        current_rule_id = int(a["act_arg"])
+                    if a["act_name"] == "chain":
+                        has_chain_action = True
+                        break
+
+                # After processing this rule:
+                # - If it has 'chain', the NEXT rule will be chained
+                # - If it doesn't have 'chain', the chain ends
+                is_chained = has_chain_action

--- a/tests/test_standalone_txn.py
+++ b/tests/test_standalone_txn.py
@@ -1,0 +1,156 @@
+import tempfile
+import os
+from crs_linter.linter import Linter, parse_config
+
+
+def test_standalone_rule_with_txn_fails():
+    """Test that standalone rule using TX.N as target is caught."""
+    invalid_rule = (
+        'SecRule TX:4 "@eq 1" \\\n'
+        '    "id:3001,\\\n'
+        '    phase:2,\\\n'
+        '    deny"'
+    )
+
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.conf', delete=False) as f:
+        f.write(invalid_rule)
+        temp_file = f.name
+
+    try:
+        parsed = parse_config(invalid_rule)
+        assert parsed is not None
+
+        linter = Linter(parsed, filename=temp_file, file_content=invalid_rule)
+        problems = list(linter.run_checks())
+
+        txn_problems = [p for p in problems if p.rule == "standalonetxn"]
+        assert len(txn_problems) > 0, \
+            "Expected error for standalone rule using TX:4"
+        assert "3001" in txn_problems[0].desc
+    finally:
+        os.unlink(temp_file)
+
+
+def test_chained_rule_with_txn_passes():
+    """Test that chained rule using TX.N as target is allowed."""
+    valid_rule = (
+        'SecRule ARGS "@rx (ab|cd)?(ef)" \\\n'
+        '    "id:3002,\\\n'
+        '    phase:2,\\\n'
+        '    deny,\\\n'
+        '    chain"\n'
+        '    SecRule TX:1 "@eq ef" \\\n'
+        '        "t:none"'
+    )
+
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.conf', delete=False) as f:
+        f.write(valid_rule)
+        temp_file = f.name
+
+    try:
+        parsed = parse_config(valid_rule)
+        assert parsed is not None
+
+        linter = Linter(parsed, filename=temp_file, file_content=valid_rule)
+        problems = list(linter.run_checks())
+
+        txn_problems = [p for p in problems if p.rule == "standalonetxn"]
+        assert len(txn_problems) == 0, \
+            "Chained rule using TX:1 should be allowed"
+    finally:
+        os.unlink(temp_file)
+
+
+def test_standalone_rule_without_txn_passes():
+    """Test that standalone rule NOT using TX.N is allowed."""
+    valid_rule = (
+        'SecRule ARGS "@rx attack" \\\n'
+        '    "id:3003,\\\n'
+        '    phase:2,\\\n'
+        '    deny"'
+    )
+
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.conf', delete=False) as f:
+        f.write(valid_rule)
+        temp_file = f.name
+
+    try:
+        parsed = parse_config(valid_rule)
+        assert parsed is not None
+
+        linter = Linter(parsed, filename=temp_file, file_content=valid_rule)
+        problems = list(linter.run_checks())
+
+        txn_problems = [p for p in problems if p.rule == "standalonetxn"]
+        assert len(txn_problems) == 0, \
+            "Standalone rule without TX.N should be allowed"
+    finally:
+        os.unlink(temp_file)
+
+
+def test_multiple_standalone_rules_with_txn_detected():
+    """Test that multiple standalone rules using TX.N are all caught."""
+    invalid_rules = (
+        'SecRule TX:0 "@eq 1" \\\n'
+        '    "id:3004,\\\n'
+        '    phase:2,\\\n'
+        '    deny"\n'
+        '\n'
+        'SecRule TX:5 "@rx foo" \\\n'
+        '    "id:3005,\\\n'
+        '    phase:2,\\\n'
+        '    deny"'
+    )
+
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.conf', delete=False) as f:
+        f.write(invalid_rules)
+        temp_file = f.name
+
+    try:
+        parsed = parse_config(invalid_rules)
+        assert parsed is not None
+
+        linter = Linter(parsed, filename=temp_file, file_content=invalid_rules)
+        problems = list(linter.run_checks())
+
+        txn_problems = [p for p in problems if p.rule == "standalonetxn"]
+        assert len(txn_problems) == 2, \
+            "Expected errors for both standalone rules using TX.N"
+    finally:
+        os.unlink(temp_file)
+
+
+def test_chain_end_followed_by_standalone_txn_fails():
+    """Test that standalone rule after chain end is caught."""
+    invalid_rules = (
+        'SecRule ARGS "@rx (test)" \\\n'
+        '    "id:3006,\\\n'
+        '    phase:2,\\\n'
+        '    deny,\\\n'
+        '    chain"\n'
+        '    SecRule TX:1 "@eq test"\n'  # This is chained, OK
+        '\n'
+        'SecRule TX:2 "@eq foo" \\\n'  # This is standalone after chain, FAIL
+        '    "id:3007,\\\n'
+        '    phase:2,\\\n'
+        '    deny"'
+    )
+
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.conf', delete=False) as f:
+        f.write(invalid_rules)
+        temp_file = f.name
+
+    try:
+        parsed = parse_config(invalid_rules)
+        assert parsed is not None
+
+        linter = Linter(parsed, filename=temp_file, file_content=invalid_rules)
+        problems = list(linter.run_checks())
+
+        txn_problems = [p for p in problems if p.rule == "standalonetxn"]
+        # Should catch the second standalone rule (3007) but not the chained one
+        assert len(txn_problems) == 1, \
+            "Expected error only for standalone rule 3007"
+        assert "3007" in txn_problems[0].desc
+    finally:
+        os.unlink(temp_file)


### PR DESCRIPTION
## what

The new rule detects and flags this problematic pattern:
```
# ❌ ERROR: Standalone rule using TX:4
SecRule TX:4 "@eq 1" "id:1001,..."
# Error: standalone rule uses TX.N as target; rule id: 1001
```
While allowing this safe pattern:
```
# ✅ OK: Chained rule where parent sets TX:1
SecRule ARGS "@rx (attack)" "id:1002,...,chain"
    SecRule TX:1 "@eq attack"
```

### Key Features

- Detects TX.N (TX:0, TX:1, etc.) used as targets in standalone rules
- Properly tracks chain boundaries
- Provides clear error messages with rule IDs
- Complements the existing CheckCapture rule

## why

- catch standalone TX:N references

## refs

- fixes #119 