### PR TITLE
fix: update tests exclusions path

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,4 +59,4 @@ jobs:
             -f util/FILENAME_EXCLUSIONS \
             -v ${{ matrix.CRS_VERSION }} \
             -T tests/regression/tests/ \
-            -E util/TESTS_EXCLUSIONS
+            -E tests/TESTS_EXCLUSIONS


### PR DESCRIPTION
## what

- update path from upstream change

## why

- we updated the file path in latest editions of CRS

