### PR TITLE
fix: replace removed dulwich.contrib.release_robot.get_recent_tags

### DIFF
--- a/src/crs_linter/utils.py
+++ b/src/crs_linter/utils.py
@@ -35,6 +35,9 @@ def get_recent_tags(projdir):
                     obj.name.decode("utf-8"),
                 )
                 obj = repo.get_object(obj.object[1])  # peel annotated tag to commit
+            if not isinstance(obj, Commit):
+                # Skip tags that don't resolve to a commit (e.g., tree/blob tags)
+                continue
             commit = obj
             tags[tag_name_bytes.decode("utf-8")] = [
                 commit.commit_time,

--- a/src/crs_linter/utils.py
+++ b/src/crs_linter/utils.py
@@ -3,7 +3,7 @@
 import re
 from semver import Version
 from dulwich.repo import Repo
-from dulwich.objects import Tag
+from dulwich.objects import Commit, Tag
 from dulwich.walk import Walker
 from collections import defaultdict
 

--- a/src/crs_linter/utils.py
+++ b/src/crs_linter/utils.py
@@ -1,12 +1,51 @@
 """Utility functions for the CRS linter"""
 
 import re
-from crs_linter.logger import Logger
 from semver import Version
-from dulwich.contrib.release_robot import get_recent_tags
 from dulwich.repo import Repo
+from dulwich.objects import Tag
 from dulwich.walk import Walker
 from collections import defaultdict
+
+
+def get_recent_tags(projdir):
+    """Return repository tags ordered from newest to oldest.
+
+    Replacement for the removed ``dulwich.contrib.release_robot.get_recent_tags``.
+
+    Args:
+        projdir: Path to the repository working directory or ``.git`` dir.
+
+    Returns:
+        A list of ``(tag_name, [commit_time, commit_sha, author, tag_meta])``
+        tuples sorted by the tag's commit time, newest first. Annotated tags are
+        peeled to the commit they point at so ``commit_sha`` is always a commit
+        hash; ``tag_meta`` is ``None`` for lightweight tags.
+    """
+    repo = Repo(projdir)
+    try:
+        tags = {}
+        for tag_name_bytes, sha in repo.refs.as_dict(b"refs/tags").items():
+            obj = repo.get_object(sha)
+            tag_meta = None
+            if isinstance(obj, Tag):
+                tag_meta = (
+                    obj.tag_time,
+                    obj.id.decode("utf-8"),
+                    obj.name.decode("utf-8"),
+                )
+                obj = repo.get_object(obj.object[1])  # peel annotated tag to commit
+            commit = obj
+            tags[tag_name_bytes.decode("utf-8")] = [
+                commit.commit_time,
+                commit.id.decode("utf-8"),
+                commit.author.decode("utf-8"),
+                tag_meta,
+            ]
+        return sorted(tags.items(), key=lambda tag: tag[1][0], reverse=True)
+    finally:
+        repo.close()
+
 
 def get_id(actions):
     """ Return the ID from actions """
@@ -58,19 +97,19 @@ def remove_comments(data):
     # regex for matching rules
     marks = re.compile("^#(| *)(SecRule|SecAction)", re.I)
     state = 0  # hold the state of the parser
-    for l in lines:
+    for line in lines:
         # if the line starts with #SecRule, #SecAction, # SecRule, # SecAction, set the marker
-        if marks.match(l):
+        if marks.match(line):
             state = 1
         # if the marker is set and the line is empty or contains only a comment, unset it
-        if state == 1 and l.strip() in ["", "#"]:
+        if state == 1 and line.strip() in ["", "#"]:
             state = 0
 
         # if marker is set, remove the comment
         if state == 1:
-            _data.append(re.sub("^#", "", l))
+            _data.append(re.sub("^#", "", line))
         else:
-            _data.append(l)
+            _data.append(line)
 
     data = "\n".join(_data)
 


### PR DESCRIPTION
## Problem

`main` is currently broken. #152 pinned `dulwich >=1.2.5,<1.3.0` for the security advisory, but dulwich `>=1.2.5` removed the `dulwich.contrib` package. The import in `utils.py`:

```python
from dulwich.contrib.release_robot import get_recent_tags
```

now raises `ModuleNotFoundError: No module named 'dulwich.contrib'`, which breaks the entire `crs_linter` import chain — the CLI and the full test suite fail to even load.

## Fix

- Add a local `get_recent_tags(projdir)` that reproduces the removed function's contract using maintained dulwich APIs (`Repo.refs.as_dict` + `get_object`). Annotated tags are peeled to their commit so the returned SHA matches the reachability walk in `parse_version_from_latest_tag`; `tag_meta` is `None` for lightweight tags. The repo handle is closed in a `finally`.
- Remove the now-unused `Logger` import and rename the ambiguous loop variable `l` → `line` (`ruff` cleanups in the touched file).

## Validation

- `uv run pytest -q` → 366 passed (previously could not collect).
- `uv run ruff check src/crs_linter/utils.py` → clean.
- Verified end-to-end on this repo: `get_recent_tags` returns tags newest-first and `parse_version_from_latest_tag` resolves the latest semver correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code structure and dependency management for better maintainability.
  * Enhanced resource cleanup in tag processing utilities to ensure proper handling of system resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->