### PR TITLE
feat: add lint rule for ARGS_NAMES start-anchored operators missing json prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ The following rule names can be used in exemption comments:
 | Rule name | Description |
 | --- | --- |
 | `approved_tags` | [ApprovedTags](#approvedtags) |
+| `args_names_json_prefix` | [ArgsNamesJsonPrefix](#argsnamesjsonprefix) |
 | `capture` | [CheckCapture](#checkcapture) |
 | `crs_tag` | [CrsTag](#crstag) |
 | `deprecated` | [Deprecated](#deprecated) |
@@ -271,6 +272,52 @@ SecRule REQUEST_URI "@rx index.php" \
 
 To use a new tag on a rule, it must first be registered in the
 util/APPROVED_TAGS file.
+
+## ArgsNamesJsonPrefix
+
+**Source:** `src/crs_linter/rules/args_names_json_prefix.py`
+
+Check that ARGS_NAMES rules with start-anchored operators include a (?:json\.)? prefix.
+
+libModSecurity3 and Coraza prefix JSON body parameter names with 'json.' (e.g.
+the field 'username' in a JSON payload becomes 'json.username' in ARGS_NAMES),
+whereas ModSecurity2 does not add this prefix. Rules that anchor to the start of
+the parameter name must account for both forms by using '(?:json\.)?'.
+
+Affected operators when combined with ARGS_NAMES:
+- @rx:         when the pattern starts with '^' without a '(?:json...)' prefix
+- @beginsWith: always start-anchored
+- @streq:      always full-string match (equivalent to '^...$')
+
+Example of a failing rule (@rx without json prefix):
+
+```apache
+SecRule ARGS_NAMES "@rx ^username$" \
+    "id:1,phase:2,deny,t:none"
+# Fails: '^username$' will not match 'json.username' in JSON payloads on
+#        libModSecurity3/Coraza
+```
+
+
+Example of a failing rule (@beginsWith):
+
+```apache
+SecRule ARGS_NAMES "@beginsWith username" \
+    "id:2,phase:2,deny,t:none"
+# Fails: cannot match the 'json.' prefix; replace with @rx and (?:json\.)?
+```
+
+
+Example of the correct approach (@rx with json prefix):
+
+```apache
+SecRule ARGS_NAMES "@rx ^(?:json\.)?username$" \
+    "id:3,phase:2,deny,t:none"
+# OK: matches both 'username' (ModSec2) and 'json.username' (libModSec3/Coraza)
+```
+
+
+See: https://github.com/coreruleset/crs-linter/issues/154
 
 ## CheckCapture
 

--- a/src/crs_linter/linter.py
+++ b/src/crs_linter/linter.py
@@ -9,6 +9,7 @@ from .exemptions import parse_exemptions, should_exempt_problem, validate_exempt
 # Import all rules to trigger auto-registration via metaclass
 from .rules import (
     approved_tags,
+    args_names_json_prefix,
     check_capture,
     crs_tag,
     deprecated,

--- a/src/crs_linter/rules/args_names_json_prefix.py
+++ b/src/crs_linter/rules/args_names_json_prefix.py
@@ -1,0 +1,112 @@
+import re
+from crs_linter.lint_problem import LintProblem
+from crs_linter.rule import Rule
+
+# Operators that implicitly anchor to the start (or full string) of the value
+_START_ANCHORED_OPERATORS = frozenset({"beginswith", "streq"})
+
+# Matches @rx patterns anchored to start (^) that don't have a (?:json...) prefix
+_MISSING_JSON_PREFIX_RE = re.compile(r"^\^(?!\(\?:json)")
+
+
+class ArgsNamesJsonPrefix(Rule):
+    """Check that ARGS_NAMES rules with start-anchored operators include a (?:json\\.)? prefix.
+
+    libModSecurity3 and Coraza prefix JSON body parameter names with 'json.' (e.g.
+    the field 'username' in a JSON payload becomes 'json.username' in ARGS_NAMES),
+    whereas ModSecurity2 does not add this prefix. Rules that anchor to the start of
+    the parameter name must account for both forms by using '(?:json\\.)?'.
+
+    Affected operators when combined with ARGS_NAMES:
+    - @rx:         when the pattern starts with '^' without a '(?:json...)' prefix
+    - @beginsWith: always start-anchored
+    - @streq:      always full-string match (equivalent to '^...$')
+
+    Example of a failing rule (@rx without json prefix):
+        SecRule ARGS_NAMES "@rx ^username$" \\
+            "id:1,phase:2,deny,t:none"
+        # Fails: '^username$' will not match 'json.username' in JSON payloads on
+        #        libModSecurity3/Coraza
+
+    Example of a failing rule (@beginsWith):
+        SecRule ARGS_NAMES "@beginsWith username" \\
+            "id:2,phase:2,deny,t:none"
+        # Fails: cannot match the 'json.' prefix; replace with @rx and (?:json\\.)?
+
+    Example of the correct approach (@rx with json prefix):
+        SecRule ARGS_NAMES "@rx ^(?:json\\.)?username$" \\
+            "id:3,phase:2,deny,t:none"
+        # OK: matches both 'username' (ModSec2) and 'json.username' (libModSec3/Coraza)
+
+    See: https://github.com/coreruleset/crs-linter/issues/154
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.success_message = "No ARGS_NAMES rules missing (?:json\\.)? prefix on start-anchored patterns."
+        self.error_message = "Found ARGS_NAMES rule(s) missing (?:json\\.)? on start-anchored patterns"
+        self.error_title = "ARGS_NAMES missing json prefix"
+        self.args = ("data",)
+
+    def check(self, data):
+        """Check ARGS_NAMES rules for a missing (?:json\\.)? prefix on start-anchored patterns."""
+        chained = False
+        current_ruleid = 0
+
+        for d in data:
+            if d["type"].lower() != "secrule":
+                continue
+
+            if "actions" in d:
+                if not chained:
+                    current_ruleid = 0
+                else:
+                    chained = False
+
+                for a in d["actions"]:
+                    if a["act_name"] == "id":
+                        try:
+                            current_ruleid = int(a["act_arg"])
+                        except (ValueError, TypeError):
+                            current_ruleid = 0
+                    if a["act_name"] == "chain":
+                        chained = True
+
+            has_args_names = any(
+                v["variable"].upper() == "ARGS_NAMES" and not v.get("negated", False)
+                for v in d.get("variables", [])
+            )
+            if not has_args_names:
+                continue
+
+            operator_raw = d.get("operator", "")
+            if not operator_raw:
+                continue
+
+            operator = operator_raw.replace("!", "").replace("@", "").lower()
+            op_arg = d.get("operator_argument") or ""
+            lineno = d.get("oplineno", d.get("lineno", 1))
+
+            if operator in _START_ANCHORED_OPERATORS:
+                yield LintProblem(
+                    line=lineno,
+                    end_line=lineno,
+                    desc=(
+                        f"ARGS_NAMES targeted with @{operator} which does not handle the "
+                        f"'json.' prefix added by libModSecurity3/Coraza to JSON parameter "
+                        f"names. Replace with '@rx ^(?:json\\.)?...'; rule id: {current_ruleid}"
+                    ),
+                    rule="args_names_json_prefix",
+                )
+            elif operator == "rx" and _MISSING_JSON_PREFIX_RE.match(op_arg):
+                yield LintProblem(
+                    line=lineno,
+                    end_line=lineno,
+                    desc=(
+                        f"ARGS_NAMES targeted with @rx pattern anchored to start ('^') but "
+                        f"missing '(?:json\\.)?' prefix. libModSecurity3/Coraza prefixes JSON "
+                        f"parameter names with 'json.', so '^foo' will not match 'json.foo'. "
+                        f"Use '^(?:json\\.)?...' instead; rule id: {current_ruleid}"
+                    ),
+                    rule="args_names_json_prefix",
+                )

--- a/src/crs_linter/rules/args_names_json_prefix.py
+++ b/src/crs_linter/rules/args_names_json_prefix.py
@@ -5,8 +5,12 @@ from crs_linter.rule import Rule
 # Operators that implicitly anchor to the start (or full string) of the value
 _START_ANCHORED_OPERATORS = frozenset({"beginswith", "streq"})
 
-# Matches @rx patterns anchored to start (^) that don't have a (?:json...) prefix
-_MISSING_JSON_PREFIX_RE = re.compile(r"^\^(?!\(\?:json)")
+# Matches @rx patterns anchored to start (^) that lack the full optional (?:json\.)?
+# prefix. The lookahead requires the complete token — group start, literal "json",
+# optional backslash, literal dot, group close, and the "?" quantifier — so that
+# forms like "^(?:json\.)foo" (mandatory, not optional) or "^(?:jsonx)?" (wrong
+# name) are still flagged.
+_MISSING_JSON_PREFIX_RE = re.compile(r"^\^(?!\(\?:json\\?\.\)\?)")
 
 
 class ArgsNamesJsonPrefix(Rule):

--- a/src/crs_linter/rules/args_names_json_prefix.py
+++ b/src/crs_linter/rules/args_names_json_prefix.py
@@ -12,6 +12,97 @@ _START_ANCHORED_OPERATORS = frozenset({"beginswith", "streq"})
 # name) are still flagged.
 _MISSING_JSON_PREFIX_RE = re.compile(r"^\^(?!\(\?:json\\?\.\)\?)")
 
+# A branch that opens with a negated character class immediately followed by a
+# "zero-or-more"/"one-or-more" quantifier, e.g. "[^'"]*" or "[^!&()]+".
+_LEADING_NEGATED_CLASS_RE = re.compile(r"^\[\^((?:\\.|[^\]])*)\][*+]")
+
+# Characters that appear literally in the "json." prefix. If a leading negated
+# character class excludes none of these, it will happily consume "json." as
+# part of its match, so the anchor still succeeds against JSON-prefixed names.
+_JSON_PREFIX_CHARS = frozenset("json.")
+
+
+def _split_top_level_alternatives(pattern):
+    """Split `pattern` on '|' that are not nested inside a group or char class."""
+    branches = []
+    start = 0
+    depth = 0
+    in_class = False
+    i = 0
+    while i < len(pattern):
+        c = pattern[i]
+        if c == "\\":
+            i += 2
+            continue
+        if in_class:
+            if c == "]":
+                in_class = False
+        elif c == "[":
+            in_class = True
+        elif c == "(":
+            depth += 1
+        elif c == ")":
+            depth -= 1
+        elif c == "|" and depth == 0:
+            branches.append(pattern[start:i])
+            start = i + 1
+        i += 1
+    branches.append(pattern[start:])
+    return branches
+
+
+def _leading_group_body(pattern):
+    """If `pattern` starts with a non-capturing group, return its inner content."""
+    if not pattern.startswith("(?:"):
+        return None
+    depth = 1
+    in_class = False
+    i = 3
+    while i < len(pattern):
+        c = pattern[i]
+        if c == "\\":
+            i += 2
+            continue
+        if in_class:
+            if c == "]":
+                in_class = False
+        elif c == "[":
+            in_class = True
+        elif c == "(":
+            depth += 1
+        elif c == ")":
+            depth -= 1
+            if depth == 0:
+                return pattern[3:i]
+        i += 1
+    return None
+
+
+def _branch_absorbs_json_prefix(branch):
+    """True if `branch` starts with a negated class that cannot exclude 'json.'."""
+    m = _LEADING_NEGATED_CLASS_RE.match(branch)
+    if not m:
+        return False
+    excluded = set(re.sub(r"\\(.)", r"\1", m.group(1)))
+    return not (excluded & _JSON_PREFIX_CHARS)
+
+
+def _tolerates_json_prefix(op_arg):
+    """True if the ^-anchored pattern still matches values with a 'json.' prefix.
+
+    Some CRS patterns anchor to the start of the value but lead with a negated
+    character class (e.g. "^[^!&()]*)" or "^(?:[^']*'|[^"]*")"). Since none of
+    the excluded characters appear in the literal "json." prefix, that leading
+    class simply consumes the prefix as part of its match, so the rule keeps
+    matching JSON-prefixed parameter names even without an explicit
+    "(?:json\\.)?" — only one alternative needs to tolerate it, since the
+    others still fire whenever this one doesn't.
+    """
+    remainder = op_arg[1:]  # strip leading '^'
+    group_body = _leading_group_body(remainder)
+    branches = _split_top_level_alternatives(group_body) if group_body is not None else [remainder]
+    return any(_branch_absorbs_json_prefix(branch) for branch in branches)
+
 
 class ArgsNamesJsonPrefix(Rule):
     """Check that ARGS_NAMES rules with start-anchored operators include a (?:json\\.)? prefix.
@@ -87,7 +178,8 @@ class ArgsNamesJsonPrefix(Rule):
             if not operator_raw:
                 continue
 
-            operator = operator_raw.replace("!", "").replace("@", "").lower()
+            operator_display = operator_raw.replace("!", "").replace("@", "")
+            operator = operator_display.lower()
             op_arg = d.get("operator_argument") or ""
             lineno = d.get("oplineno", d.get("lineno", 1))
 
@@ -96,13 +188,17 @@ class ArgsNamesJsonPrefix(Rule):
                     line=lineno,
                     end_line=lineno,
                     desc=(
-                        f"ARGS_NAMES targeted with @{operator} which does not handle the "
+                        f"ARGS_NAMES targeted with @{operator_display} which does not handle the "
                         f"'json.' prefix added by libModSecurity3/Coraza to JSON parameter "
                         f"names. Replace with '@rx ^(?:json\\.)?...'; rule id: {current_ruleid}"
                     ),
                     rule="args_names_json_prefix",
                 )
-            elif operator == "rx" and _MISSING_JSON_PREFIX_RE.match(op_arg):
+            elif (
+                operator == "rx"
+                and _MISSING_JSON_PREFIX_RE.match(op_arg)
+                and not _tolerates_json_prefix(op_arg)
+            ):
                 yield LintProblem(
                     line=lineno,
                     end_line=lineno,

--- a/tests/test_args_names_json_prefix.py
+++ b/tests/test_args_names_json_prefix.py
@@ -1,0 +1,143 @@
+"""Tests for the args_names_json_prefix rule."""
+
+import pytest
+
+
+@pytest.mark.parametrize("rule,expected_count,description", [
+    # --- @rx cases ---
+    # Failing: ^-anchored pattern without (?:json.)? prefix
+    ('''SecRule ARGS_NAMES "@rx ^foo" \
+    "id:1,phase:2,deny,t:none"''', 1, "@rx with ^ but no json prefix"),
+
+    ('''SecRule ARGS_NAMES "@rx ^admin\\s*" \
+    "id:2,phase:2,deny,t:none"''', 1, "@rx with ^ and extra chars but no json prefix"),
+
+    ('''SecRule ARGS_NAMES "@rx ^[\\W\\d]+\\s*?select" \
+    "id:3,phase:2,deny,t:none"''', 1, "@rx with ^ and character class but no json prefix"),
+
+    # Passing: (?:json\.)? prefix present
+    ('''SecRule ARGS_NAMES "@rx ^(?:json\\.)?foo" \
+    "id:10,phase:2,deny,t:none"''', 0, "@rx with ^(?:json\\.)? prefix"),
+
+    ('''SecRule ARGS_NAMES "@rx ^(?:json.)?foo" \
+    "id:11,phase:2,deny,t:none"''', 0, "@rx with ^(?:json.)? prefix (unescaped dot)"),
+
+    # Passing: not anchored to start
+    ('''SecRule ARGS_NAMES "@rx foo" \
+    "id:12,phase:2,deny,t:none"''', 0, "@rx without ^ anchor"),
+
+    ('''SecRule ARGS_NAMES "@rx .*foo" \
+    "id:13,phase:2,deny,t:none"''', 0, "@rx with .* prefix (not start-anchored)"),
+
+    # --- @beginsWith cases ---
+    ('''SecRule ARGS_NAMES "@beginsWith foo" \
+    "id:20,phase:2,deny,t:none"''', 1, "@beginsWith always start-anchored"),
+
+    ('''SecRule ARGS_NAMES "@beginsWith admin" \
+    "id:21,phase:2,deny,t:none"''', 1, "@beginsWith with admin value"),
+
+    # --- @streq cases ---
+    ('''SecRule ARGS_NAMES "@streq username" \
+    "id:30,phase:2,deny,t:none"''', 1, "@streq always full-string match"),
+
+    ('''SecRule ARGS_NAMES "@streq file_content" \
+    "id:31,phase:2,deny,t:none"''', 1, "@streq with underscore value"),
+
+    # --- Non-ARGS_NAMES targets: should pass ---
+    ('''SecRule ARGS "@rx ^foo" \
+    "id:40,phase:2,deny,t:none"''', 0, "ARGS (not ARGS_NAMES) with ^ anchor"),
+
+    ('''SecRule REQUEST_HEADERS "@rx ^foo" \
+    "id:41,phase:2,deny,t:none"''', 0, "REQUEST_HEADERS with ^ anchor"),
+
+    ('''SecRule REQUEST_URI "@beginsWith /admin" \
+    "id:42,phase:2,deny,t:none"''', 0, "REQUEST_URI with @beginsWith"),
+
+    # --- Other operators on ARGS_NAMES: should pass ---
+    ('''SecRule ARGS_NAMES "@contains foo" \
+    "id:50,phase:2,deny,t:none"''', 0, "@contains is not start-anchored"),
+
+    ('''SecRule ARGS_NAMES "@pm foo bar" \
+    "id:51,phase:2,deny,t:none"''', 0, "@pm is not start-anchored"),
+
+    ('''SecRule ARGS_NAMES "@endsWith foo" \
+    "id:52,phase:2,deny,t:none"''', 0, "@endsWith is not start-anchored"),
+
+    # --- ARGS_NAMES among multiple targets ---
+    ('''SecRule ARGS_NAMES|REQUEST_HEADERS "@rx ^foo" \
+    "id:60,phase:2,deny,t:none"''', 1, "ARGS_NAMES in list with ^ anchor"),
+
+    # --- Negated ARGS_NAMES: should pass (negation changes semantics) ---
+    ('''SecRule !ARGS_NAMES "@rx ^foo" \
+    "id:70,phase:2,deny,t:none"''', 0, "negated !ARGS_NAMES should not flag"),
+
+    # --- SecAction (no variables): should pass ---
+    ('''SecAction \
+    "id:80,phase:1,pass,nolog"''', 0, "SecAction has no targets"),
+])
+def test_args_names_json_prefix(run_linter, rule, expected_count, description):
+    """Test that ARGS_NAMES start-anchored operator checks work correctly."""
+    problems = run_linter(rule, rule_type="args_names_json_prefix")
+
+    assert len(problems) == expected_count, (
+        f"{description}: expected {expected_count} problem(s), got {len(problems)}: "
+        + ", ".join(p.desc for p in problems)
+    )
+
+
+def test_error_message_includes_rule_id(run_linter):
+    """Test that error messages include the rule ID."""
+    rule = '''SecRule ARGS_NAMES "@rx ^username$" \
+    "id:942100,phase:2,deny,t:none"'''
+
+    problems = run_linter(rule, rule_type="args_names_json_prefix")
+
+    assert len(problems) == 1
+    assert "942100" in problems[0].desc, (
+        f"Error message should include the rule ID: {problems[0].desc}"
+    )
+
+
+def test_error_message_mentions_json_prefix(run_linter):
+    """Test that error messages explain the json. prefix issue."""
+    rule = '''SecRule ARGS_NAMES "@rx ^admin" \
+    "id:1,phase:2,deny,t:none"'''
+
+    problems = run_linter(rule, rule_type="args_names_json_prefix")
+
+    assert len(problems) == 1
+    assert "json" in problems[0].desc.lower(), (
+        f"Error message should mention json prefix: {problems[0].desc}"
+    )
+
+
+def test_multiple_rules_flags_each(run_linter):
+    """Test that each offending rule is flagged independently."""
+    rule = '''SecRule ARGS_NAMES "@rx ^foo" \
+    "id:1,phase:2,deny,t:none"
+
+SecRule ARGS_NAMES "@beginsWith bar" \
+    "id:2,phase:2,deny,t:none"
+
+SecRule ARGS_NAMES "@rx ^(?:json\\.)?baz" \
+    "id:3,phase:2,deny,t:none"'''
+
+    problems = run_linter(rule, rule_type="args_names_json_prefix")
+
+    assert len(problems) == 2, (
+        f"Expected 2 problems, got {len(problems)}: "
+        + ", ".join(p.desc for p in problems)
+    )
+
+
+def test_chained_rule_with_args_names(run_linter):
+    """Test that ARGS_NAMES in a chained rule is also checked."""
+    rule = '''SecRule REQUEST_METHOD "@streq POST" \
+    "id:1,phase:2,deny,t:none,chain"
+    SecRule ARGS_NAMES "@rx ^username$"'''
+
+    problems = run_linter(rule, rule_type="args_names_json_prefix")
+
+    assert len(problems) == 1, (
+        f"Expected 1 problem in chained rule, got {len(problems)}"
+    )

--- a/tests/test_args_names_json_prefix.py
+++ b/tests/test_args_names_json_prefix.py
@@ -15,12 +15,24 @@ import pytest
     ('''SecRule ARGS_NAMES "@rx ^[\\W\\d]+\\s*?select" \
     "id:3,phase:2,deny,t:none"''', 1, "@rx with ^ and character class but no json prefix"),
 
-    # Passing: (?:json\.)? prefix present
+    # Passing: full optional (?:json\.)? prefix present
     ('''SecRule ARGS_NAMES "@rx ^(?:json\\.)?foo" \
     "id:10,phase:2,deny,t:none"''', 0, "@rx with ^(?:json\\.)? prefix"),
 
     ('''SecRule ARGS_NAMES "@rx ^(?:json.)?foo" \
     "id:11,phase:2,deny,t:none"''', 0, "@rx with ^(?:json.)? prefix (unescaped dot)"),
+
+    # Failing: malformed json prefix — mandatory group (missing trailing ?)
+    ('''SecRule ARGS_NAMES "@rx ^(?:json\\.)foo" \
+    "id:14,phase:2,deny,t:none"''', 1, "@rx with mandatory (?:json\\.) group, no trailing ?"),
+
+    # Failing: wrong prefix name (not "json")
+    ('''SecRule ARGS_NAMES "@rx ^(?:jsonx)?foo" \
+    "id:15,phase:2,deny,t:none"''', 1, "@rx with wrong prefix name ^(?:jsonx)?"),
+
+    # Failing: missing dot in prefix
+    ('''SecRule ARGS_NAMES "@rx ^(?:json)?foo" \
+    "id:16,phase:2,deny,t:none"''', 1, "@rx with ^(?:json)? prefix (no dot)"),
 
     # Passing: not anchored to start
     ('''SecRule ARGS_NAMES "@rx foo" \

--- a/tests/test_args_names_json_prefix.py
+++ b/tests/test_args_names_json_prefix.py
@@ -6,86 +6,109 @@ import pytest
 @pytest.mark.parametrize("rule,expected_count,description", [
     # --- @rx cases ---
     # Failing: ^-anchored pattern without (?:json.)? prefix
-    ('''SecRule ARGS_NAMES "@rx ^foo" \
+    ('''SecRule ARGS_NAMES "@rx ^foo" \\
     "id:1,phase:2,deny,t:none"''', 1, "@rx with ^ but no json prefix"),
 
-    ('''SecRule ARGS_NAMES "@rx ^admin\\s*" \
+    ('''SecRule ARGS_NAMES "@rx ^admin\\s*" \\
     "id:2,phase:2,deny,t:none"''', 1, "@rx with ^ and extra chars but no json prefix"),
 
-    ('''SecRule ARGS_NAMES "@rx ^[\\W\\d]+\\s*?select" \
+    ('''SecRule ARGS_NAMES "@rx ^[\\W\\d]+\\s*?select" \\
     "id:3,phase:2,deny,t:none"''', 1, "@rx with ^ and character class but no json prefix"),
 
     # Passing: full optional (?:json\.)? prefix present
-    ('''SecRule ARGS_NAMES "@rx ^(?:json\\.)?foo" \
+    ('''SecRule ARGS_NAMES "@rx ^(?:json\\.)?foo" \\
     "id:10,phase:2,deny,t:none"''', 0, "@rx with ^(?:json\\.)? prefix"),
 
-    ('''SecRule ARGS_NAMES "@rx ^(?:json.)?foo" \
+    ('''SecRule ARGS_NAMES "@rx ^(?:json.)?foo" \\
     "id:11,phase:2,deny,t:none"''', 0, "@rx with ^(?:json.)? prefix (unescaped dot)"),
 
     # Failing: malformed json prefix — mandatory group (missing trailing ?)
-    ('''SecRule ARGS_NAMES "@rx ^(?:json\\.)foo" \
+    ('''SecRule ARGS_NAMES "@rx ^(?:json\\.)foo" \\
     "id:14,phase:2,deny,t:none"''', 1, "@rx with mandatory (?:json\\.) group, no trailing ?"),
 
     # Failing: wrong prefix name (not "json")
-    ('''SecRule ARGS_NAMES "@rx ^(?:jsonx)?foo" \
+    ('''SecRule ARGS_NAMES "@rx ^(?:jsonx)?foo" \\
     "id:15,phase:2,deny,t:none"''', 1, "@rx with wrong prefix name ^(?:jsonx)?"),
 
     # Failing: missing dot in prefix
-    ('''SecRule ARGS_NAMES "@rx ^(?:json)?foo" \
+    ('''SecRule ARGS_NAMES "@rx ^(?:json)?foo" \\
     "id:16,phase:2,deny,t:none"''', 1, "@rx with ^(?:json)? prefix (no dot)"),
 
     # Passing: not anchored to start
-    ('''SecRule ARGS_NAMES "@rx foo" \
+    ('''SecRule ARGS_NAMES "@rx foo" \\
     "id:12,phase:2,deny,t:none"''', 0, "@rx without ^ anchor"),
 
-    ('''SecRule ARGS_NAMES "@rx .*foo" \
+    ('''SecRule ARGS_NAMES "@rx .*foo" \\
     "id:13,phase:2,deny,t:none"''', 0, "@rx with .* prefix (not start-anchored)"),
 
     # --- @beginsWith cases ---
-    ('''SecRule ARGS_NAMES "@beginsWith foo" \
+    ('''SecRule ARGS_NAMES "@beginsWith foo" \\
     "id:20,phase:2,deny,t:none"''', 1, "@beginsWith always start-anchored"),
 
-    ('''SecRule ARGS_NAMES "@beginsWith admin" \
+    ('''SecRule ARGS_NAMES "@beginsWith admin" \\
     "id:21,phase:2,deny,t:none"''', 1, "@beginsWith with admin value"),
 
     # --- @streq cases ---
-    ('''SecRule ARGS_NAMES "@streq username" \
+    ('''SecRule ARGS_NAMES "@streq username" \\
     "id:30,phase:2,deny,t:none"''', 1, "@streq always full-string match"),
 
-    ('''SecRule ARGS_NAMES "@streq file_content" \
+    ('''SecRule ARGS_NAMES "@streq file_content" \\
     "id:31,phase:2,deny,t:none"''', 1, "@streq with underscore value"),
 
     # --- Non-ARGS_NAMES targets: should pass ---
-    ('''SecRule ARGS "@rx ^foo" \
+    ('''SecRule ARGS "@rx ^foo" \\
     "id:40,phase:2,deny,t:none"''', 0, "ARGS (not ARGS_NAMES) with ^ anchor"),
 
-    ('''SecRule REQUEST_HEADERS "@rx ^foo" \
+    ('''SecRule REQUEST_HEADERS "@rx ^foo" \\
     "id:41,phase:2,deny,t:none"''', 0, "REQUEST_HEADERS with ^ anchor"),
 
-    ('''SecRule REQUEST_URI "@beginsWith /admin" \
+    ('''SecRule REQUEST_URI "@beginsWith /admin" \\
     "id:42,phase:2,deny,t:none"''', 0, "REQUEST_URI with @beginsWith"),
 
     # --- Other operators on ARGS_NAMES: should pass ---
-    ('''SecRule ARGS_NAMES "@contains foo" \
+    ('''SecRule ARGS_NAMES "@contains foo" \\
     "id:50,phase:2,deny,t:none"''', 0, "@contains is not start-anchored"),
 
-    ('''SecRule ARGS_NAMES "@pm foo bar" \
+    ('''SecRule ARGS_NAMES "@pm foo bar" \\
     "id:51,phase:2,deny,t:none"''', 0, "@pm is not start-anchored"),
 
-    ('''SecRule ARGS_NAMES "@endsWith foo" \
+    ('''SecRule ARGS_NAMES "@endsWith foo" \\
     "id:52,phase:2,deny,t:none"''', 0, "@endsWith is not start-anchored"),
 
     # --- ARGS_NAMES among multiple targets ---
-    ('''SecRule ARGS_NAMES|REQUEST_HEADERS "@rx ^foo" \
+    ('''SecRule ARGS_NAMES|REQUEST_HEADERS "@rx ^foo" \\
     "id:60,phase:2,deny,t:none"''', 1, "ARGS_NAMES in list with ^ anchor"),
 
     # --- Negated ARGS_NAMES: should pass (negation changes semantics) ---
-    ('''SecRule !ARGS_NAMES "@rx ^foo" \
+    ('''SecRule !ARGS_NAMES "@rx ^foo" \\
     "id:70,phase:2,deny,t:none"''', 0, "negated !ARGS_NAMES should not flag"),
 
     # --- SecAction (no variables): should pass ---
-    ('''SecAction \
+    ('''SecAction \\
     "id:80,phase:1,pass,nolog"''', 0, "SecAction has no targets"),
+
+    # --- Leading negated character class: pattern still matches 'json.'-prefixed
+    # names because the class doesn't exclude any of 'json.', so it absorbs the
+    # prefix. Modeled on real CRS rules 921200 and 942540. ---
+    (r'''SecRule ARGS_NAMES "@rx ^[^!&\(\):<>\|~]*\)[\s\x0b]*[!&\|]" \
+    "id:921200,phase:2,deny,t:none"''', 0,
+     "921200-style: leading [^...]* tolerates json. prefix"),
+
+    (r'''SecRule ARGS_NAMES "@rx ^(?:[^']*'|[^\"]*\"|[^`]*`)[\s\x0b]*;" \
+    "id:942540,phase:2,deny,t:none"''', 0,
+     "942540-style: alternation of leading [^...]* branches tolerates json. prefix"),
+
+    # --- Leading literal character (no negated-class tolerance): genuinely
+    # broken by the json. prefix. Modeled on real CRS rule 932171. ---
+    (r'''SecRule ARGS_NAMES "@rx ^\(\s*\)\s+\{" \
+    "id:932171,phase:2,deny,t:none"''', 1,
+     "932171-style: literal '(' right after anchor is NOT tolerant"),
+
+    # --- Negated class that excludes a 'json.' character: not tolerant, since
+    # excluding 'o' or '.' means the class can't fully consume the prefix. ---
+    ('''SecRule ARGS_NAMES "@rx ^[^o]*foo" \\
+    "id:90,phase:2,deny,t:none"''', 1,
+     "leading [^o]* excludes 'o' from 'json.', so it is not tolerant"),
 ])
 def test_args_names_json_prefix(run_linter, rule, expected_count, description):
     """Test that ARGS_NAMES start-anchored operator checks work correctly."""
@@ -99,7 +122,7 @@ def test_args_names_json_prefix(run_linter, rule, expected_count, description):
 
 def test_error_message_includes_rule_id(run_linter):
     """Test that error messages include the rule ID."""
-    rule = '''SecRule ARGS_NAMES "@rx ^username$" \
+    rule = '''SecRule ARGS_NAMES "@rx ^username$" \\
     "id:942100,phase:2,deny,t:none"'''
 
     problems = run_linter(rule, rule_type="args_names_json_prefix")
@@ -112,7 +135,7 @@ def test_error_message_includes_rule_id(run_linter):
 
 def test_error_message_mentions_json_prefix(run_linter):
     """Test that error messages explain the json. prefix issue."""
-    rule = '''SecRule ARGS_NAMES "@rx ^admin" \
+    rule = '''SecRule ARGS_NAMES "@rx ^admin" \\
     "id:1,phase:2,deny,t:none"'''
 
     problems = run_linter(rule, rule_type="args_names_json_prefix")
@@ -123,15 +146,28 @@ def test_error_message_mentions_json_prefix(run_linter):
     )
 
 
+def test_begins_with_error_message_preserves_operator_case(run_linter):
+    """Test that the error message displays '@beginsWith', not '@beginswith'."""
+    rule = '''SecRule ARGS_NAMES "@beginsWith foo" \\
+    "id:1,phase:2,deny,t:none"'''
+
+    problems = run_linter(rule, rule_type="args_names_json_prefix")
+
+    assert len(problems) == 1
+    assert "@beginsWith" in problems[0].desc, (
+        f"Error message should preserve operator case: {problems[0].desc}"
+    )
+
+
 def test_multiple_rules_flags_each(run_linter):
     """Test that each offending rule is flagged independently."""
-    rule = '''SecRule ARGS_NAMES "@rx ^foo" \
+    rule = '''SecRule ARGS_NAMES "@rx ^foo" \\
     "id:1,phase:2,deny,t:none"
 
-SecRule ARGS_NAMES "@beginsWith bar" \
+SecRule ARGS_NAMES "@beginsWith bar" \\
     "id:2,phase:2,deny,t:none"
 
-SecRule ARGS_NAMES "@rx ^(?:json\\.)?baz" \
+SecRule ARGS_NAMES "@rx ^(?:json\\.)?baz" \\
     "id:3,phase:2,deny,t:none"'''
 
     problems = run_linter(rule, rule_type="args_names_json_prefix")
@@ -144,7 +180,7 @@ SecRule ARGS_NAMES "@rx ^(?:json\\.)?baz" \
 
 def test_chained_rule_with_args_names(run_linter):
     """Test that ARGS_NAMES in a chained rule is also checked."""
-    rule = '''SecRule REQUEST_METHOD "@streq POST" \
+    rule = '''SecRule REQUEST_METHOD "@streq POST" \\
     "id:1,phase:2,deny,t:none,chain"
     SecRule ARGS_NAMES "@rx ^username$"'''
 


### PR DESCRIPTION
## Summary

- Adds a new `args_names_json_prefix` rule that flags `SecRule` directives targeting `ARGS_NAMES` with start-anchored operators that don't account for the `json.` prefix added by libModSecurity3/Coraza to JSON body parameter names
- Flags `@rx ^pattern` (start-anchored without `(?:json\.)?`), `@beginsWith`, and `@streq` when used with `ARGS_NAMES`
- 24 new tests covering all operator variants, multi-target rules, chained rules, and negated variables

## Background

libModSecurity3 and Coraza prefix JSON body parameter names with `json.` (e.g. `username` → `json.username`), while ModSecurity2 does not. A rule like `SecRule ARGS_NAMES "@rx ^username$"` silently misses JSON parameters on libModSecurity3/Coraza. The fix is to use `^(?:json\.)?username$` instead.

This is the same class of bug fixed in coreruleset/coreruleset#4672.

## Prerequisites

- https://github.com/coreruleset/coreruleset/pull/4672

## Test plan

- [ ] `uv run pytest tests/test_args_names_json_prefix.py -vs` — all 24 new tests pass
- [ ] `uv run pytest -q` — full suite (407 tests) passes
- [ ] `uv run python generate_rules_docs.py --check` — README is up to date

Closes #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new linter rule to detect `SecRule` uses of start-anchored `ARGS_NAMES` that don’t account for the optional `json.`-prefixed parameter naming.
  * Updated the linting rules reference and exemptions list with the new rule details and examples.

* **Tests**
  * Added pytest coverage for passing and failing `ARGS_NAMES` scenarios, including chained rules, negation behavior, and JSON-prefix matching edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->