### PR TITLE
chore: update CRS_VERSION to 4.28.0 in test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: true
       matrix:
         # renovate: datasource=github-releases depName=coreruleset/coreruleset versioning=semver
-        CRS_VERSION: ['4.26.0']
+        CRS_VERSION: ['4.28.0']
         python-version: ['3.11', '3.12', '3.13']
 
     steps:


### PR DESCRIPTION
## what

- just update crs to get all new fixes

## why

- be able to push the latest version with new lint options

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the regression test workflow to use a newer ruleset version during test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->